### PR TITLE
Fix language major mode editing

### DIFF
--- a/inferior-plisp.el
+++ b/inferior-plisp.el
@@ -254,7 +254,8 @@ Needs `inferior-picolisp-provide-inferior-picolisp' set to `t'."
   (if inferior-plisp-provide-inferior-picolisp
       (progn
         (provide 'inferior-picolisp)
-        (defalias 'run-picolisp 'inferior-plisp-run-picolisp))
+        (defalias 'run-picolisp 'inferior-plisp-run-picolisp)
+        (plisp-support-ob-picolisp))
     (error "Unable to support ob-picolisp: please ensure 'inferior-plisp-provide-inferior-picolisp' is set to 't'")))
 
 ;;;###autoload (add-hook 'same-window-buffer-names "*picolisp*")

--- a/plisp-mode.el
+++ b/plisp-mode.el
@@ -760,6 +760,17 @@ specified by `plisp-documentation-method'."
     (switch-to-buffer "*picolisp-repl*")
     (plisp-repl-mode)))
 
+;;;###autoload
+(defun plisp-support-ob-picolisp ()
+  "Enable (reachback) support for `ob-picolisp'."
+  (interactive)
+  (cond ((not (boundp 'inferior-plisp-provide-inferior-picolisp))
+         (error "Please ensure that the `inferior-plisp' feature is provided"))
+        (inferior-plisp-provide-inferior-picolisp
+         (defalias 'picolisp-mode 'plisp-mode)
+         (provide 'picolisp-mode))
+        (t (error "Unable to support ob-picolisp: please ensure 'inferior-plisp-provide-inferior-picolisp' is set to 't'"))))
+
 
 ;; --
 


### PR DESCRIPTION
When this project was renamed recently from `picolisp-mode` to `plisp-mode`, language major mode editing a la https://orgmode.org/manual/Editing-source-code.html stopped working, that is, picolisp source code blocks in Org Babel documents could not be edited in language major mode when the user pressed C-'.

This fix allows language major mode editing to work once again.

Background. When the user presses C-' while point is in a picolisp source code block, Org Babel is looking for the major mode `picolisp-mode` (*exactly*) and fails to find it, absent this patch. The patch simply provides the feature and the entry function `picolisp-mode`.

Please feel free to improve, re-write, whatever into something that best accomplishes the goal of being able to do language major mode editing in Org Babel.  I'm not married to this code, nor do I need credit.  It would be very convenient though to have this functionality upstream.  Thanks! Rick