### PR TITLE
Hide inferior-picolisp from Emacsmirror

### DIFF
--- a/inferior-plisp.el
+++ b/inferior-plisp.el
@@ -346,7 +346,7 @@ Needs `inferior-picolisp-provide-inferior-picolisp' set to `t'."
   (interactive)
   (if inferior-plisp-provide-inferior-picolisp
       (progn
-        (provide 'inferior-picolisp)
+        (provide (quote inferior-picolisp))
         (defalias 'run-picolisp 'inferior-plisp-run-picolisp))
     (error "Unable to support ob-picolisp: please ensure 'inferior-plisp-provide-inferior-picolisp' is set to 't'")))
 


### PR DESCRIPTION
By using   (provide (quote inferior-picolisp)
instead of (provide 'inferior-picolisp)
provided feature is hidden from the tools used by the Emacsmirror.

See comments on
- https://github.com/flexibeast/plisp-mode/commit/d6083244
- https://github.com/flexibeast/plisp-mode/commit/3984816a

Thanks for your work on this.  When I originally raised this issue I hoped that would keep it from becoming one of the special cases that need a permanent kludge like [these](https://emacsmirror.net/stats/kludges.html#orgc312339).  And with this little additional patch it doesn't have to, so I hope you are willing to merge this.